### PR TITLE
allow recursive generic type aliases 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "js-compile-bundle": "rollup --environment BUNDLE:true --config build/rollup.config.js --sourcemap",
     "js-compile-plugins": "node build/build-plugins.js",
     "js-compile-plugins-coverage": "cross-env NODE_ENV=test node build/build-plugins.js",
-    "js-lint": "npm-run-all --parallel js-lint-*",
+    "js-lint": "npm-run-all --continue-on-error --parallel js-lint-*",
     "js-lint-main": "eslint --cache --cache-location .cache/.eslintcache js/src js/tests build/",
     "js-lint-docs": "eslint --cache --cache-location .cache/.eslintcache site/",
     "js-minify": "npm-run-all --parallel js-minify-main js-minify-docs",


### PR DESCRIPTION
So if one of the two sub-tasks fails, it still completes linting the other one.