### PR TITLE
keyof for arrays

### DIFF
--- a/scss/mixins/_breakpoints.scss
+++ b/scss/mixins/_breakpoints.scss
@@ -16,7 +16,10 @@
 //    md
 @function breakpoint-next($name, $breakpoints: $grid-breakpoints, $breakpoint-names: map-keys($breakpoints)) {
   $n: index($breakpoint-names, $name);
-  @return if($n != null and $n < length($breakpoint-names), nth($breakpoint-names, $n + 1), null);
+  @if not $n {
+    @error "breakpoint `#{$name}` not found in `#{$breakpoints}`";
+  }
+  @return if($n < length($breakpoint-names), nth($breakpoint-names, $n + 1), null);
 }
 
 // Minimum breakpoint width. Null for the smallest (first) breakpoint.


### PR DESCRIPTION
* Add Error checking to prevent invalid breakpoint

Error checking to prevent invalid breakpoint name

* check type rather than value

* Revert "check type rather than value"

This reverts commit 04ab1e652f9c9c1c7725b7328b12f548a2c6d142.

* use of not rather than null